### PR TITLE
Add status bar plugin representing ACPI information

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A list of tmux plugins.
 - [tmux-ticker](https://github.com/Brutuski/tmux-ticker) - Keep a track of popular market indexes and stock price.
 - [tmux-urlview](https://github.com/tmux-plugins/tmux-urlview) - Quickly open any url on your terminal window!
 - [tmux-weather](https://github.com/aaronpowell/tmux-weather) - Display weather information in your terminal.
+- [tmux-acpi](https://github.com/briansalehi/tmux-acpi) - Display ACPI information including thermal status, battery health, battery percentage, and adapter status.
 
 
 ## Themes


### PR DESCRIPTION
It's been days since I feel some information missing on the status bar of my tmux sessions including the temprature of my device and wether my device is plugged or not, so I tried to write a plugin aiming acpi command output, now this plugin does even more including battery percentage which was already covered by other plugins and battery health percentage and capacity. I will be glad to see if this plugin also helps other tmux lovers out there. Cheers to the community.